### PR TITLE
Add AUTHORS, CHANGELOG, CONTRIBUTING

### DIFF
--- a/{{cookiecutter.repo_name}}/AUTHORS.md
+++ b/{{cookiecutter.repo_name}}/AUTHORS.md
@@ -1,0 +1,19 @@
+# Authors
+
+{{cookiecutter.project_name}} was created by {{cookiecutter.author_name}} in {% now 'utc', '%Y' %}.
+
+
+All contributing authors are listed in this file below.
+The repository history at https://github.com/{{cookiecutter.github_url}}
+and the CHANGELOG show individual code contributions.
+
+## Chronological list of authors
+
+<!--
+The rules for this file:
+  * Authors are sorted chronologically
+  * Please give the name you go by, not your GitHub username
+  * Don't ever delete anything
+-->
+
+- {{cookiecutter.author_name}}

--- a/{{cookiecutter.repo_name}}/AUTHORS.md
+++ b/{{cookiecutter.repo_name}}/AUTHORS.md
@@ -11,9 +11,11 @@ and the CHANGELOG show individual code contributions.
 
 <!--
 The rules for this file:
-  * Authors are sorted chronologically
+  * Authors are sorted chronologically, earliest to latest
   * Please give the name you go by, not your GitHub username
+  * Please start a new section for each new year
   * Don't ever delete anything
 -->
 
+**{% now 'utc', '%Y' %}**
 - {{cookiecutter.author_name}}

--- a/{{cookiecutter.repo_name}}/AUTHORS.md
+++ b/{{cookiecutter.repo_name}}/AUTHORS.md
@@ -12,10 +12,12 @@ and the CHANGELOG show individual code contributions.
 <!--
 The rules for this file:
   * Authors are sorted chronologically, earliest to latest
-  * Please give the name you go by, not your GitHub username
+  * Please format it each entry as "Preferred name <GitHub username>"
+  * Your preferred name is whatever you wish to go by --
+    it does *not* have to be your legal name!
   * Please start a new section for each new year
   * Don't ever delete anything
 -->
 
 **{% now 'utc', '%Y' %}**
-- {{cookiecutter.author_name}}
+- {{cookiecutter.author_name}} \<@{{cookiecutter.github_username}}\>

--- a/{{cookiecutter.repo_name}}/CHANGELOG.md
+++ b/{{cookiecutter.repo_name}}/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!--
+The rules for this file:
+  * entries are sorted newest-first.
+  * summarize sets of changes - don't reproduce every git log comment here.
+  * don't ever delete anything.
+  * keep the format consistent (79 char width, M/D/Y date format) and do not
+    use tabs but use spaces for formatting
+  * accompany each entry with github issue/PR number (Issue #xyz)
+-->
+
+## [Unreleased]
+
+### Authors
+<!-- GitHub usernames of contributors to this release -->
+
+### Added
+<!-- New added features -->
+
+### Fixed
+<!-- Bug fixes -->
+
+### Changed
+<!-- Changes in existing functionality -->
+
+### Deprecated
+<!-- Soon-to-be removed features -->
+
+### Removed
+<!-- Removed features -->

--- a/{{cookiecutter.repo_name}}/CHANGELOG.md
+++ b/{{cookiecutter.repo_name}}/CHANGELOG.md
@@ -9,8 +9,10 @@ The rules for this file:
   * entries are sorted newest-first.
   * summarize sets of changes - don't reproduce every git log comment here.
   * don't ever delete anything.
-  * keep the format consistent (79 char width, M/D/Y date format) and do not
-    use tabs but use spaces for formatting
+  * keep the format consistent:
+    * do not use tabs but use spaces for formatting
+    * 79 char width
+    * YYYY-MM-DD date format (following ISO 8601)
   * accompany each entry with github issue/PR number (Issue #xyz)
 -->
 

--- a/{{cookiecutter.repo_name}}/CONTRIBUTING.md
+++ b/{{cookiecutter.repo_name}}/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# How to contribute
+
+We welcome all contributions to {{cookiecutter.project_name}}!
+
+Contributions can take many forms, such as:
+
+* sharing bug reports or feature requests through the [Issue Tracker](https://github.com/{{cookiecutter.github_url}}/issues)
+* asking or answering questions, or otherwise joining in on discussions
+* adding bug fixes, new features, or otherwise improving the code
+* adding or improving documentation
+
+The second two options both involve making a [pull request](https://github.com/{{cookiecutter.github_url}}/pulls) .
+
+There are many existing guides on how to make a contribution to an open
+source project on GitHub. In short, the steps are to:
+
+  * Ensure that you have a [GitHub account](https://github.com/signup/free)
+  * [Fork](https://help.github.com/articles/fork-a-repo/) the repository into your own account
+  * On your local machine, [clone](https://help.github.com/articles/cloning-a-repository/) your fork
+  * Create a development environment from source, following the Installation from source instructions
+  * Create a new branch off the `main` branch with a meaningful name (e.g. ``git checkout -b fix-issue-39``)
+  * Add your modifications to the code or documentation
+  * Add tests if modifying the code
+  * Commit and push changes to GitHub, and open a pull request
+
+Guides such as the [MDAnalysis User Guide](https://userguide.mdanalysis.org/stable/contributing.html)
+have been written in much more detail to go through these steps more thoroughly.
+We strongly encourage you to check those for help, and we welcome any questions.
+Thank you for your contribution!


### PR DESCRIPTION
This PR adds the files we are accustomed to in https://github.com/MDAnalysis/mdanalysis but are not in MolSSI's cookiecutter. However, I have made the following changes:

* they're all Markdown
* The "rules" are commented so only visible to people editing the file
* I adapted the "Keep a Changelog" sections and made the contributors an explicit section, instead of hewing more closely to MDAnalysis's current format

My reasoning for this is that Markdown is just much easier to work with than rst; you can preview it and type directly into GitHub, for example. Having some kind of formatting also makes it easier to read in GitHub instead of just a straight text file. To get authors for the documentation might require a little more fancy regex, but not by much.

Please see examples at:

* https://github.com/lilyminium/test_mda_condaforge_rtd/blob/main/AUTHORS.md
* https://github.com/lilyminium/test_mda_condaforge_rtd/blob/main/CHANGELOG.md
* https://github.com/lilyminium/test_mda_condaforge_rtd/blob/main/CONTRIBUTING.md

I'll do code of conduct in a separate one.